### PR TITLE
048 pages and routes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,7 @@
-import { BrowserRouter as Router, Route } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
+import Home from './pages/Home';
+import About from './pages/About';
+import NotFound from './pages/NotFound';
 import Navbar from './components/layout/Navbar';
 import Footer from './components/layout/Footer';
 
@@ -7,7 +10,14 @@ function App() {
 		<Router>
 			<div className='flex flex-col justify-between h-screen'>
 				<Navbar />
-				<main className='container mx-auto px-3 pb-12'>Content</main>
+				<main className='container mx-auto px-3 pb-12'>
+					<Routes>
+						<Route path='/' element={<Home />} />
+						<Route path='/about' element={<About />} />
+						<Route path='/notfound' element={<NotFound />} />
+						<Route path='/*' element={<NotFound />} />
+					</Routes>
+				</main>
 				<Footer />
 			</div>
 		</Router>

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -1,0 +1,12 @@
+function About() {
+	return (
+		<div>
+			<h1 className='text-6xl mb-4'>gitlink</h1>
+			<p className='mb-4 text-2xl font-light'>Description [To Be Written]</p>
+			<p className='text-lg text-gray-400'>
+				Version: <span className='text-white'>1.0.0</span>
+			</p>
+		</div>
+	);
+}
+export default About;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,0 +1,8 @@
+function Home() {
+	return (
+		<div>
+			<h1 className='text-6xl'>Welcome</h1>
+		</div>
+	);
+}
+export default Home;

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,0 +1,20 @@
+import { FaHome } from 'react-icons/fa';
+import { Link } from 'react-router-dom';
+
+function NotFound() {
+	return (
+		<div className='hero'>
+			<div className='text-center hero-content'>
+				<div className='max-w-lg'>
+					<h1 className='text-8xl font-bold mb-8'>Whoopsie!</h1>
+					<p className='text-5xl mb-8'>404 - Page Not Found!</p>
+					<Link to='/' className='btn btn-primary btn-lg'>
+						<FaHome className='mr-2' />
+						Back To Home
+					</Link>
+				</div>
+			</div>
+		</div>
+	);
+}
+export default NotFound;


### PR DESCRIPTION
Following the instructions outlined in Brad Traversy's lesson 48 video in "React: Front to Back 2022" on Udemy, several changes were made to this project:

- Create `About` Page Component
  - Create `pages` directory
  - Create `About.jsx` component file
  - Create base scaffold code for component
  - Include "Description" section to be updated upon project's completion
- Create `Home` Component
  - Created `Home.jsx` component in `pages` directory
  - Created base scaffold code for later update throughout project
- Create `NotFound` Component
  - Create `NotFound.jsx` file in `pages` directory
  - Created scaffold code for redirect back to `Home` component
- Extract `Routes`, Create Page `Routes` Navigation
  - Extract `Routes` from `react-router-dom` package
  - Import `Home`, `About`, `NotFound` components
  - Wrap page routing in `Routes` tag
  - Create page routing for more specific navigation around site

Minimal testing was performed by just running the "dev" server and making live changes in the code to see those changes reflected in the UI.

Resolves #4 