### PR TITLE
052 display users

### DIFF
--- a/src/components/users/UserItem.jsx
+++ b/src/components/users/UserItem.jsx
@@ -1,0 +1,32 @@
+import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
+
+function UserItem({ user: { login, avatar_url } }) {
+	return (
+		<div className='card shadow-md compact side bg-base-100'>
+			<div className='flex-row items-center space-x-4 card-body'>
+				<div>
+					<div className='avatar'>
+						<div className='rounded-full shadow w-14 h-14'>
+							<img src={avatar_url} alt='Profile' />
+						</div>
+					</div>
+				</div>
+				<div>
+					<h2 className='card-title'>{login}</h2>
+					<Link
+						className='text-base-content text-opacity-40'
+						to={`/users/${login}`}>
+						Visit Profile
+					</Link>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+UserItem.propTypes = {
+	user: PropTypes.object.isRequired,
+};
+
+export default UserItem;

--- a/src/components/users/UserResults.jsx
+++ b/src/components/users/UserResults.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import Spinner from '../layout/Spinner';
+import UserItem from './UserItem';
 
 function UserResults() {
 	const [users, setUsers] = useState([]);
@@ -26,7 +27,7 @@ function UserResults() {
 		return (
 			<div className='grid grid-cols-1 gap-8 xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2'>
 				{users.map((user) => (
-					<h3 key={user.id}>{user.login}</h3>
+					<UserItem key={user.id} user={user} />
 				))}
 			</div>
 		);


### PR DESCRIPTION
Following the instructions outlined in Brad Traversy's lesson 52 video in "React: Front to Back 2022" on Udemy, several changes were made to this project:

- Create `UserItem` Component
  - Create `UserItem.jsx` file
  - Extract `Link` & import `PropTypes` for use in component
  - Create base repeat-use component for search results
  - Extract `login`, `avatar_url` for use in repeatable cards
  - Create `Link` for card to user profile
  - Established `PropTypes` for prop validation in the component
- Import/Instantiate `UserItem` Component
  - Import `UserItem` component
  - Instantiate `UserItem` component with key and props

Minimal testing was performed by just running the "dev" server and making live changes in the code to see those changes reflected in the UI.

Resolves #8 