### PR TITLE
053 setup GitHub context

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,23 +4,26 @@ import About from './pages/About';
 import NotFound from './pages/NotFound';
 import Navbar from './components/layout/Navbar';
 import Footer from './components/layout/Footer';
+import { GithubProvider } from './context/github/GithubContext';
 
 function App() {
 	return (
-		<Router>
-			<div className='flex flex-col justify-between h-screen'>
-				<Navbar />
-				<main className='container mx-auto px-3 pb-12'>
-					<Routes>
-						<Route path='/' element={<Home />} />
-						<Route path='/about' element={<About />} />
-						<Route path='/notfound' element={<NotFound />} />
-						<Route path='/*' element={<NotFound />} />
-					</Routes>
-				</main>
-				<Footer />
-			</div>
-		</Router>
+		<GithubProvider>
+			<Router>
+				<div className='flex flex-col justify-between h-screen'>
+					<Navbar />
+					<main className='container mx-auto px-3 pb-12'>
+						<Routes>
+							<Route path='/' element={<Home />} />
+							<Route path='/about' element={<About />} />
+							<Route path='/notfound' element={<NotFound />} />
+							<Route path='/*' element={<NotFound />} />
+						</Routes>
+					</main>
+					<Footer />
+				</div>
+			</Router>
+		</GithubProvider>
 	);
 }
 

--- a/src/components/users/UserResults.jsx
+++ b/src/components/users/UserResults.jsx
@@ -1,27 +1,14 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useContext } from 'react';
 import Spinner from '../layout/Spinner';
 import UserItem from './UserItem';
+import GithubContext from '../../context/github/GithubContext';
 
 function UserResults() {
-	const [users, setUsers] = useState([]);
-	const [isLoading, setIsLoading] = useState(true);
+	const { users, isLoading, fetchUsers } = useContext(GithubContext);
 
 	useEffect(() => {
 		fetchUsers();
 	}, []);
-
-	const fetchUsers = async () => {
-		const response = await fetch(`${process.env.REACT_APP_GITHUB_URL}/users`, {
-			headers: {
-				Authorization: `token ${process.env.REACT_APP_GITHUB_TOKEN}`,
-			},
-		});
-
-		const data = await response.json();
-
-		setUsers(data);
-		setIsLoading(false);
-	};
 
 	if (!isLoading) {
 		return (

--- a/src/context/github/GithubContext.js
+++ b/src/context/github/GithubContext.js
@@ -1,0 +1,32 @@
+import { createContext, useState } from 'react';
+
+const GithubContext = createContext();
+
+const GITHUB_URL = process.env.REACT_APP_GITHUB_URL;
+const GITHUB_TOKEN = process.env.REACT_APP_GITHUB_TOKEN;
+
+export const GithubProvider = ({ children }) => {
+	const [users, setUsers] = useState([]);
+	const [isLoading, setIsLoading] = useState(true);
+
+	const fetchUsers = async () => {
+		const response = await fetch(`${GITHUB_URL}/users`, {
+			headers: {
+				Authorization: `token ${GITHUB_TOKEN}`,
+			},
+		});
+
+		const data = await response.json();
+
+		setUsers(data);
+		setIsLoading(false);
+	};
+
+	return (
+		<GithubContext.Provider value={{ users, isLoading, fetchUsers }}>
+			{children}
+		</GithubContext.Provider>
+	);
+};
+
+export default GithubContext;


### PR DESCRIPTION
Following the instructions outlined in Brad Traversy's lesson 53 video in "React: Front to Back 2022" on Udemy, several changes were made to this project:

- Update `UserResults` To Utillize Context API
  - Replace extracted `useState` hook with `useContext`
  - Import new `GithubContext`
  - Move `useState` from `UserResults` to `GithubContext` file
  - Move `fetchUsers` from `UserResults` to `GithubContext` file
  - Extract `users`, `isLoading`, `fetchUsers` from `GithubContext`
- Import `GithubProvider` & Wrap Return
  - Import `GithubProvider`
  - Wrap return with `GithubProvider` to use global state/context API
- Create `GithubContext`
  - Create `context` directory
  - Create `github` directory in `context` directory
  - Create `GithubContext.js` in `github` directory
  - Create scaffold context/global state for use in app
    - Move `useState` from `UserResults` to `GithubContext` file
    - Move `fetchUsers` from `UserResults` to `GithubContext` file

Minimal testing was performed by just running the "dev" server and making live changes in the code to see those changes reflected in the UI as well as in the Chrome React Developer Tools.

Resolves #9 