### PR TITLE
055 clean up fetch users

### DIFF
--- a/src/components/users/UserResults.jsx
+++ b/src/components/users/UserResults.jsx
@@ -1,14 +1,10 @@
-import { useEffect, useContext } from 'react';
+import { useContext } from 'react';
 import Spinner from '../layout/Spinner';
 import UserItem from './UserItem';
 import GithubContext from '../../context/github/GithubContext';
 
 function UserResults() {
-	const { users, isLoading, fetchUsers } = useContext(GithubContext);
-
-	useEffect(() => {
-		fetchUsers();
-	}, []);
+	const { users, isLoading } = useContext(GithubContext);
 
 	if (!isLoading) {
 		return (

--- a/src/context/github/GithubContext.js
+++ b/src/context/github/GithubContext.js
@@ -9,12 +9,14 @@ const GITHUB_TOKEN = process.env.REACT_APP_GITHUB_TOKEN;
 export const GithubProvider = ({ children }) => {
 	const initialState = {
 		users: [],
-		isLoading: true,
+		isLoading: false,
 	};
 
 	const [state, dispatch] = useReducer(githubReducer, initialState);
 
+	// Get Initial Users (For Testing Purposes)
 	const fetchUsers = async () => {
+		setIsLoading();
 		const response = await fetch(`${GITHUB_URL}/users`, {
 			headers: {
 				Authorization: `token ${GITHUB_TOKEN}`,
@@ -28,6 +30,9 @@ export const GithubProvider = ({ children }) => {
 			payload: data,
 		});
 	};
+
+	// Set isLoading
+	const setIsLoading = () => dispatch({type: 'SET_LOADING'})
 
 	return (
 		<GithubContext.Provider

--- a/src/context/github/GithubReducer.js
+++ b/src/context/github/GithubReducer.js
@@ -6,6 +6,11 @@ const githubReducer = (state, action) => {
 				users: action.payload,
 				isLoading: false,
 			};
+		case 'SET_LOADING':
+				return {
+					...state,
+					isLoading: true,
+				}
 		default:
 			return state;
 	}


### PR DESCRIPTION
Following the instructions outlined in Brad Traversy's lesson 55 video in "React: Front to Back 2022" on Udemy, several changes were made to this project:

- Create `SET_LOADING` Case In Reducer
  - Create `SET_LOADING` case in reducer that sets `isLoading` to true
- Clean Up `UserResults` From Original Testing
  - Remove `useEffect` hook extract
  - Remove `fetchUsers` from context API/global state extract
  - Remove `useEffect` hook call
- Amend `initialState`; Add Comments + `setIsLoading`
  - Change `isLoading` in `initialState` from true to false
  - Add comment re: `fetchUsers` function
  - Add `setIsLoading` function to `fetchUsers`
  - Create `setIsLoading` function

Minimal testing was performed by just running the "dev" server and making live changes in the code to see those changes reflected in the UI as well as in the Chrome React Developer Tools.

Resolves #11 