### PR TITLE
057 search users

### DIFF
--- a/src/components/users/UserSearch.jsx
+++ b/src/components/users/UserSearch.jsx
@@ -4,7 +4,7 @@ import GithubContext from '../../context/github/GithubContext';
 function UserSearch() {
 	const [text, setText] = useState('');
 
-	const { users } = useContext(GithubContext);
+	const { users, searchUsers } = useContext(GithubContext);
 
 	const handleChange = (e) => setText(e.target.value);
 
@@ -14,7 +14,7 @@ function UserSearch() {
 		if (text === '') {
 			alert('Please Enter Something');
 		} else {
-			// @todo - search users
+			searchUsers(text);
 
 			setText('');
 		}

--- a/src/context/github/GithubContext.js
+++ b/src/context/github/GithubContext.js
@@ -14,29 +14,34 @@ export const GithubProvider = ({ children }) => {
 
 	const [state, dispatch] = useReducer(githubReducer, initialState);
 
-	// Get Initial Users (For Testing Purposes)
-	const fetchUsers = async () => {
+	// Get Search Results
+	const searchUsers = async (text) => {
 		setIsLoading();
-		const response = await fetch(`${GITHUB_URL}/users`, {
+
+		const params = new URLSearchParams({
+			q: text,
+		});
+
+		const response = await fetch(`${GITHUB_URL}/search/users?${params}`, {
 			headers: {
 				Authorization: `token ${GITHUB_TOKEN}`,
 			},
 		});
 
-		const data = await response.json();
+		const { items } = await response.json();
 
 		dispatch({
 			type: 'GET_USERS',
-			payload: data,
+			payload: items,
 		});
 	};
 
 	// Set isLoading
-	const setIsLoading = () => dispatch({type: 'SET_LOADING'})
+	const setIsLoading = () => dispatch({ type: 'SET_LOADING' });
 
 	return (
 		<GithubContext.Provider
-			value={{ users: state.users, isLoading: state.isLoading, fetchUsers }}>
+			value={{ users: state.users, isLoading: state.isLoading, searchUsers }}>
 			{children}
 		</GithubContext.Provider>
 	);


### PR DESCRIPTION
Following the instructions outlined in Brad Traversy's lesson 57 video in "React: Front to Back 2022" on Udemy, several changes were made to this project:

- Update `GithubContext` With User Search
  - Changed `fetchUsers` to `searchUsers` function
  - Amended comment
  - Added `params` variable containing search parameters from text box
  - Update fetch in `response` to take `params` variable as query
  - Destructure `items` out of response from Github API
  - Changed payload to take in `items` instead of `data`
  - Reformatted `setIsLoading` for cleanliness
  - Changed export of `fetchUsers` to `searchUsers`
- Extract `searchUsers` From Context/Global State
  - Extract `searchUsers` function from Context API/Global State
  - Replace `todo` comment with `searchUsers` function

Minimal testing was performed by just running the "dev" server and making live changes in the code to see those changes reflected in the UI as well as in the Chrome React Developer Tools.

Resolves #13 