### PR TITLE
061 get single user

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import Home from './pages/Home';
 import About from './pages/About';
+import User from './pages/User';
 import NotFound from './pages/NotFound';
 import Navbar from './components/layout/Navbar';
 import Footer from './components/layout/Footer';
@@ -20,6 +21,7 @@ function App() {
 							<Routes>
 								<Route path='/' element={<Home />} />
 								<Route path='/about' element={<About />} />
+								<Route path='/user/:login' element={<User />} />
 								<Route path='/notfound' element={<NotFound />} />
 								<Route path='/*' element={<NotFound />} />
 							</Routes>

--- a/src/components/users/UserItem.jsx
+++ b/src/components/users/UserItem.jsx
@@ -16,7 +16,7 @@ function UserItem({ user: { login, avatar_url } }) {
 					<h2 className='card-title'>{login}</h2>
 					<Link
 						className='text-base-content text-opacity-40'
-						to={`/users/${login}`}>
+						to={`/user/${login}`}>
 						Visit Profile
 					</Link>
 				</div>

--- a/src/context/github/GithubContext.js
+++ b/src/context/github/GithubContext.js
@@ -9,6 +9,7 @@ const GITHUB_TOKEN = process.env.REACT_APP_GITHUB_TOKEN;
 export const GithubProvider = ({ children }) => {
 	const initialState = {
 		users: [],
+		user: {},
 		isLoading: false,
 	};
 
@@ -36,6 +37,28 @@ export const GithubProvider = ({ children }) => {
 		});
 	};
 
+	// Get Single User
+	const getUser = async (login) => {
+		setIsLoading();
+
+		const response = await fetch(`${GITHUB_URL}/users/${login}`, {
+			headers: {
+				Authorization: `token ${GITHUB_TOKEN}`,
+			},
+		});
+
+		if (response.status === 404) {
+			window.location = '/notfound';
+		} else {
+			const data = await response.json();
+
+			dispatch({
+				type: 'GET_USER',
+				payload: data,
+			});
+		}
+	};
+
 	// Clear Users From State
 	const clearUsers = () => dispatch({ type: 'CLEAR_USERS' });
 
@@ -46,8 +69,10 @@ export const GithubProvider = ({ children }) => {
 		<GithubContext.Provider
 			value={{
 				users: state.users,
+				user: state.user,
 				isLoading: state.isLoading,
 				searchUsers,
+				getUser,
 				clearUsers,
 			}}>
 			{children}

--- a/src/context/github/GithubReducer.js
+++ b/src/context/github/GithubReducer.js
@@ -6,6 +6,12 @@ const githubReducer = (state, action) => {
 				users: action.payload,
 				isLoading: false,
 			};
+		case 'GET_USER':
+			return {
+				...state,
+				user: action.payload,
+				isLoading: false,
+			};
 		case 'SET_LOADING':
 			return {
 				...state,

--- a/src/pages/User.jsx
+++ b/src/pages/User.jsx
@@ -1,0 +1,16 @@
+import { useEffect, useContext } from 'react';
+import GithubContext from '../context/github/GithubContext';
+import { useParams } from 'react-router-dom';
+
+function User() {
+	const { getUser, user } = useContext(GithubContext);
+
+	const params = useParams();
+
+	useEffect(() => {
+		getUser(params.login);
+	}, []);
+
+	return <div>{user.login}</div>;
+}
+export default User;


### PR DESCRIPTION
Following the instructions outlined in Brad Traversy's lesson 61 video in "React: Front to Back 2022" on Udemy, several changes were made to this project:

- Import/Instantiate `User` Component
  - Import `User` component
  - Instantiate `User` component
  - Create `User` route
- Amend `Visit Profile` Link URL
  - Change `Visit Profile` URL so it directs to user singular not users
- Add `getUser` Function; `user` State
  - Add `user` object to `initialState`
  - Create `getUser` function to retrieve a single user's info from search
  - Return `user` state value & `getUser` function
- Add `GET_USER` Case To Reducer
- Create `User` Component
  - Create `User.jsx` file in `pages` directory
  - Create basic `User` component to be a new page displaying user info

Minimal testing was performed by just running the "dev" server and making live changes in the code to see those changes reflected in the UI as well as in the Chrome React Developer Tools.

Resolves #17 