### PR TITLE
065 repo items

### DIFF
--- a/src/components/repos/RepoItem.jsx
+++ b/src/components/repos/RepoItem.jsx
@@ -1,0 +1,46 @@
+import { FaEye, FaInfo, FaLink, FaStar, FaUtensils } from 'react-icons/fa';
+import PropTypes from 'prop-types';
+
+function RepoItem({ repo }) {
+	const {
+		name,
+		description,
+		html_url,
+		forks,
+		open_issues,
+		watchers_count,
+		stargazers_count,
+	} = repo;
+
+	return (
+		<div className='mb-2 rounded-md card bg-gray-800 hover:bg-gray-900'>
+			<div className='card-body'>
+				<h3 className='mb-2 text-xl font-semibold'>
+					<a href={html_url}>
+						<FaLink className='inline mr-1' /> {name}
+					</a>
+				</h3>
+				<p className='mb-3'>{description}</p>
+				<div>
+					<div className='mr-2 badge badge-info badge-lg'>
+						<FaEye className='mr-2' /> {watchers_count}
+					</div>
+					<div className='mr-2 badge badge-success badge-lg'>
+						<FaStar className='mr-2' /> {stargazers_count}
+					</div>
+					<div className='mr-2 badge badge-error badge-lg'>
+						<FaInfo className='mr-2' /> {open_issues}
+					</div>
+					<div className='mr-2 badge badge-warning badge-lg'>
+						<FaUtensils className='mr-2' /> {forks}
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+RepoItem.propTypes = {
+	repo: PropTypes.object.isRequired,
+};
+export default RepoItem;

--- a/src/components/repos/RepoList.jsx
+++ b/src/components/repos/RepoList.jsx
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import RepoItem from './RepoItem';
 
 function RepoList({ repos }) {
 	return (
@@ -8,7 +9,7 @@ function RepoList({ repos }) {
 					Latest Repositories
 				</h2>
 				{repos.map((repo) => (
-					<h3 key={repo.id}>{repo.name}</h3>
+					<RepoItem key={repo.id} repo={repo} />
 				))}
 			</div>
 		</div>


### PR DESCRIPTION
Following the instructions outlined in Brad Traversy's lesson 65 video in "React: Front to Back 2022" on Udemy, several changes were made to this project:

- Import/Instantiate `RepoItem` Component
  - Import `RepoItem` component
  - Instantiate `RepoItem` component using .map
- Create `RepoItem.jsx` File, Scaffold Component
  - Create `RepoItem.jsx` file in `repos` directory
  - Import several `react-icons`
  - Create scaffold `RepoItem` component, extracting several data points
  - Add data signaled by `react-icons`

Minimal testing was performed by just running the "dev" server and making live changes in the code to see those changes reflected in the UI as well as in the Chrome React Developer Tools.

Resolves #21 