### PR TITLE
066 move searchusers to actions file

### DIFF
--- a/src/components/users/UserSearch.jsx
+++ b/src/components/users/UserSearch.jsx
@@ -1,22 +1,25 @@
 import { useState, useContext } from 'react';
 import GithubContext from '../../context/github/GithubContext';
 import AlertContext from '../../context/alert/AlertContext';
+import { searchUsers } from '../../context/github/GithubActions';
 
 function UserSearch() {
 	const [text, setText] = useState('');
 
-	const { users, searchUsers, clearUsers } = useContext(GithubContext);
+	const { users, dispatch, clearUsers } = useContext(GithubContext);
 	const { setAlert } = useContext(AlertContext);
 
 	const handleChange = (e) => setText(e.target.value);
 
-	const handleSubmit = (e) => {
+	const handleSubmit = async (e) => {
 		e.preventDefault();
 
 		if (text === '') {
 			setAlert('Please Enter Something', 'error');
 		} else {
-			searchUsers(text);
+			dispatch({ type: 'SET_LOADING' });
+			const users = await searchUsers(text);
+			dispatch({ type: 'GET_USERS', payload: users });
 
 			setText('');
 		}

--- a/src/context/github/GithubActions.js
+++ b/src/context/github/GithubActions.js
@@ -1,0 +1,19 @@
+const GITHUB_URL = process.env.REACT_APP_GITHUB_URL;
+const GITHUB_TOKEN = process.env.REACT_APP_GITHUB_TOKEN;
+
+// Get Search Results
+export const searchUsers = async (text) => {
+	const params = new URLSearchParams({
+		q: text,
+	});
+
+	const response = await fetch(`${GITHUB_URL}/search/users?${params}`, {
+		headers: {
+			Authorization: `token ${GITHUB_TOKEN}`,
+		},
+	});
+
+	const { items } = await response.json();
+
+	return items;
+};

--- a/src/context/github/GithubContext.js
+++ b/src/context/github/GithubContext.js
@@ -16,28 +16,6 @@ export const GithubProvider = ({ children }) => {
 
 	const [state, dispatch] = useReducer(githubReducer, initialState);
 
-	// Get Search Results
-	const searchUsers = async (text) => {
-		setIsLoading();
-
-		const params = new URLSearchParams({
-			q: text,
-		});
-
-		const response = await fetch(`${GITHUB_URL}/search/users?${params}`, {
-			headers: {
-				Authorization: `token ${GITHUB_TOKEN}`,
-			},
-		});
-
-		const { items } = await response.json();
-
-		dispatch({
-			type: 'GET_USERS',
-			payload: items,
-		});
-	};
-
 	// Get Single User
 	const getUser = async (login) => {
 		setIsLoading();
@@ -95,11 +73,8 @@ export const GithubProvider = ({ children }) => {
 	return (
 		<GithubContext.Provider
 			value={{
-				users: state.users,
-				user: state.user,
-				isLoading: state.isLoading,
-				repos: state.repos,
-				searchUsers,
+				...state,
+				dispatch,
 				getUser,
 				clearUsers,
 				getUserRepos,


### PR DESCRIPTION
Following the instructions outlined in Brad Traversy's lesson 66 video in "React: Front to Back 2022" on Udemy, several changes were made to this project:

- Create `GithubActions.js` File, Move `searchUsers`
  - Create `GithubActions.js` file
  - Move secret reference to this file
  - Move & export `searchUsers` function to this file
- Import/Instantiate `GithubActions` Into Component
  - Import `GithubActions`, extract `searchUsers` function
  - Extract `dispatch` from Context API
  - Make `handleSubmit` async
  - Add `dispatch` to conditional check
  - Create `users` variable, assign return of `searchUsers` function
- Remove `searchUsers`, Spread State, Add `dispatch`
  - Moved `searchUsers` function to `GithubActions` file
  - Spread `state` in `Provider`
  - Export `dispatch` in `Provider`

Minimal testing was performed by just running the "dev" server and making live changes in the code to see those changes reflected in the UI as well as in the Chrome React Developer Tools.

Resolves #22 