### PR TITLE
067 move getuser to actions file

### DIFF
--- a/src/components/users/UserSearch.jsx
+++ b/src/components/users/UserSearch.jsx
@@ -6,7 +6,7 @@ import { searchUsers } from '../../context/github/GithubActions';
 function UserSearch() {
 	const [text, setText] = useState('');
 
-	const { users, dispatch, clearUsers } = useContext(GithubContext);
+	const { users, dispatch } = useContext(GithubContext);
 	const { setAlert } = useContext(AlertContext);
 
 	const handleChange = (e) => setText(e.target.value);
@@ -49,7 +49,9 @@ function UserSearch() {
 			</div>
 			{users.length > 0 && (
 				<div>
-					<button onClick={clearUsers} className='btn btn-ghost btn-lg'>
+					<button
+						onClick={() => dispatch({ type: 'CLEAR_USERS' })}
+						className='btn btn-ghost btn-lg'>
 						Clear
 					</button>
 				</div>

--- a/src/context/github/GithubActions.js
+++ b/src/context/github/GithubActions.js
@@ -17,3 +17,38 @@ export const searchUsers = async (text) => {
 
 	return items;
 };
+
+// Get Single User
+export const getUser = async (login) => {
+	const response = await fetch(`${GITHUB_URL}/users/${login}`, {
+		headers: {
+			Authorization: `token ${GITHUB_TOKEN}`,
+		},
+	});
+
+	if (response.status === 404) {
+		window.location = '/notfound';
+	} else {
+		const data = await response.json();
+
+		return data;
+	}
+};
+
+// Get User Repos
+export const getUserRepos = async (login) => {
+	const params = new URLSearchParams({
+		sort: 'created',
+		per_page: 10,
+	});
+
+	const response = await fetch(`${GITHUB_URL}/users/${login}/repos?${params}`, {
+		headers: {
+			Authorization: `token ${GITHUB_TOKEN}`,
+		},
+	});
+
+	const data = await response.json();
+
+	return data;
+};

--- a/src/context/github/GithubContext.js
+++ b/src/context/github/GithubContext.js
@@ -3,9 +3,6 @@ import githubReducer from './GithubReducer';
 
 const GithubContext = createContext();
 
-const GITHUB_URL = process.env.REACT_APP_GITHUB_URL;
-const GITHUB_TOKEN = process.env.REACT_APP_GITHUB_TOKEN;
-
 export const GithubProvider = ({ children }) => {
 	const initialState = {
 		users: [],
@@ -16,68 +13,11 @@ export const GithubProvider = ({ children }) => {
 
 	const [state, dispatch] = useReducer(githubReducer, initialState);
 
-	// Get Single User
-	const getUser = async (login) => {
-		setIsLoading();
-
-		const response = await fetch(`${GITHUB_URL}/users/${login}`, {
-			headers: {
-				Authorization: `token ${GITHUB_TOKEN}`,
-			},
-		});
-
-		if (response.status === 404) {
-			window.location = '/notfound';
-		} else {
-			const data = await response.json();
-
-			dispatch({
-				type: 'GET_USER',
-				payload: data,
-			});
-		}
-	};
-
-	// Get User Repos
-	const getUserRepos = async (login) => {
-		setIsLoading();
-
-		const params = new URLSearchParams({
-			sort: 'created',
-			per_page: 10,
-		});
-
-		const response = await fetch(
-			`${GITHUB_URL}/users/${login}/repos?${params}`,
-			{
-				headers: {
-					Authorization: `token ${GITHUB_TOKEN}`,
-				},
-			}
-		);
-
-		const data = await response.json();
-
-		dispatch({
-			type: 'GET_REPOS',
-			payload: data,
-		});
-	};
-
-	// Clear Users From State
-	const clearUsers = () => dispatch({ type: 'CLEAR_USERS' });
-
-	// Set isLoading
-	const setIsLoading = () => dispatch({ type: 'SET_LOADING' });
-
 	return (
 		<GithubContext.Provider
 			value={{
 				...state,
 				dispatch,
-				getUser,
-				clearUsers,
-				getUserRepos,
 			}}>
 			{children}
 		</GithubContext.Provider>

--- a/src/pages/User.jsx
+++ b/src/pages/User.jsx
@@ -5,16 +5,24 @@ import Spinner from '../components/layout/Spinner';
 import GithubContext from '../context/github/GithubContext';
 import { useParams } from 'react-router-dom';
 import RepoList from '../components/repos/RepoList';
+import { getUser, getUserRepos } from '../context/github/GithubActions';
 
 function User() {
-	const { getUser, user, isLoading, getUserRepos, repos } =
-		useContext(GithubContext);
+	const { user, isLoading, repos, dispatch } = useContext(GithubContext);
 
 	const params = useParams();
 
 	useEffect(() => {
-		getUser(params.login);
-		getUserRepos(params.login);
+		dispatch({ type: 'SET_LOADING' });
+		const getUserData = async () => {
+			const userData = await getUser(params.login);
+			dispatch({ type: 'GET_USER', payload: userData });
+
+			const userRepoData = await getUserRepos(params.login);
+			dispatch({ type: 'GET_REPOS', payload: userRepoData });
+		};
+
+		getUserData();
 	}, []);
 
 	const {


### PR DESCRIPTION
Following the instructions outlined in Brad Traversy's lesson 67 video in "React: Front to Back 2022" on Udemy, several changes were made to this project:

- Remove Several Functions
  - Remove reference to secrets in file
  - Remove `getUser` function, moving it to `GithubActions` file
  - Remove `getUserRepos` function, moving it to `GithubActions` file
  - Remove `clearUsers` function
  - Remove `setIsLoading` function
  - Remove reference to dropped functions in `Provider`
- Remove/Replace `clearUsers` Function
  - Remove `clearUsers` function from Context API extract
  - Create arrow function, dispatching `CLEAR_USERS` call instead
- Import/Extract `GithubActions`, Update `useEffect`
  - Import `GithubActions` file
  - Extract `getUser`, `getUserRepos` from `GithubActions` file
  - Remove `getUser`, `getUserRepos` extract from Context API
  - Update `useEffect` hook to use `dispatch`,  `GithubActions` functions
- Add `getUser`, `getUserRepos` to `GithubActions`


Minimal testing was performed by just running the "dev" server and making live changes in the code to see those changes reflected in the UI as well as in the Chrome React Developer Tools.

Resolves #23 