### PR TITLE
068 cleaning up our actions and axios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.16.3",
         "@testing-library/react": "^12.1.4",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^0.26.1",
         "daisyui": "^2.13.6",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
@@ -4453,6 +4454,14 @@
       "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
       }
     },
     "node_modules/axobject-query": {
@@ -19342,6 +19351,14 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz",
       "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw=="
+    },
+    "axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "requires": {
+        "follow-redirects": "^1.14.8"
+      }
     },
     "axobject-query": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.16.3",
     "@testing-library/react": "^12.1.4",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^0.26.1",
     "daisyui": "^2.13.6",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/src/context/github/GithubActions.js
+++ b/src/context/github/GithubActions.js
@@ -1,5 +1,11 @@
+import axios from 'axios';
 const GITHUB_URL = process.env.REACT_APP_GITHUB_URL;
 const GITHUB_TOKEN = process.env.REACT_APP_GITHUB_TOKEN;
+
+const github = axios.create({
+	baseURL: GITHUB_URL,
+	headers: { Authorization: `token ${GITHUB_TOKEN}` },
+});
 
 // Get Search Results
 export const searchUsers = async (text) => {
@@ -7,48 +13,16 @@ export const searchUsers = async (text) => {
 		q: text,
 	});
 
-	const response = await fetch(`${GITHUB_URL}/search/users?${params}`, {
-		headers: {
-			Authorization: `token ${GITHUB_TOKEN}`,
-		},
-	});
-
-	const { items } = await response.json();
-
-	return items;
+	const response = await github.get(`/search/users/${params}`);
+	return response.data.items;
 };
 
-// Get Single User
-export const getUser = async (login) => {
-	const response = await fetch(`${GITHUB_URL}/users/${login}`, {
-		headers: {
-			Authorization: `token ${GITHUB_TOKEN}`,
-		},
-	});
+// Get User & Repos
+export const getUserAndRepos = async (login) => {
+	const [user, repos] = await Promise.all([
+		github.get(`/users/${login}`),
+		github.get(`/users/${login}/repos`),
+	]);
 
-	if (response.status === 404) {
-		window.location = '/notfound';
-	} else {
-		const data = await response.json();
-
-		return data;
-	}
-};
-
-// Get User Repos
-export const getUserRepos = async (login) => {
-	const params = new URLSearchParams({
-		sort: 'created',
-		per_page: 10,
-	});
-
-	const response = await fetch(`${GITHUB_URL}/users/${login}/repos?${params}`, {
-		headers: {
-			Authorization: `token ${GITHUB_TOKEN}`,
-		},
-	});
-
-	const data = await response.json();
-
-	return data;
+	return { user: user.data, repos: repos.data };
 };

--- a/src/context/github/GithubActions.js
+++ b/src/context/github/GithubActions.js
@@ -13,7 +13,7 @@ export const searchUsers = async (text) => {
 		q: text,
 	});
 
-	const response = await github.get(`/search/users/${params}`);
+	const response = await github.get(`/search/users?${params}`);
 	return response.data.items;
 };
 

--- a/src/context/github/GithubReducer.js
+++ b/src/context/github/GithubReducer.js
@@ -6,16 +6,11 @@ const githubReducer = (state, action) => {
 				users: action.payload,
 				isLoading: false,
 			};
-		case 'GET_USER':
+		case 'GET_USER_AND_REPOS':
 			return {
 				...state,
-				user: action.payload,
-				isLoading: false,
-			};
-		case 'GET_REPOS':
-			return {
-				...state,
-				repos: action.payload,
+				user: action.payload.user,
+				repos: action.payload.repos,
 				isLoading: false,
 			};
 		case 'SET_LOADING':

--- a/src/pages/User.jsx
+++ b/src/pages/User.jsx
@@ -5,7 +5,7 @@ import Spinner from '../components/layout/Spinner';
 import GithubContext from '../context/github/GithubContext';
 import { useParams } from 'react-router-dom';
 import RepoList from '../components/repos/RepoList';
-import { getUser, getUserRepos } from '../context/github/GithubActions';
+import { getUserAndRepos } from '../context/github/GithubActions';
 
 function User() {
 	const { user, isLoading, repos, dispatch } = useContext(GithubContext);
@@ -15,11 +15,8 @@ function User() {
 	useEffect(() => {
 		dispatch({ type: 'SET_LOADING' });
 		const getUserData = async () => {
-			const userData = await getUser(params.login);
-			dispatch({ type: 'GET_USER', payload: userData });
-
-			const userRepoData = await getUserRepos(params.login);
-			dispatch({ type: 'GET_REPOS', payload: userRepoData });
+			const userData = await getUserAndRepos(params.login);
+			dispatch({ type: 'GET_USER_AND_REPOS', payload: userData });
 		};
 
 		getUserData();


### PR DESCRIPTION
Following the instructions outlined in Brad Traversy's lesson 68 video in "React: Front to Back 2022" on Udemy, several changes were made to this project:

- Import `axios` Package
- Import `axios`, Create `axios` Instance
  - Import `axios`
  - Create `axios` instance for accessing Github
  - Update `searchUsers` to use axios
  - Merge `getUser`, `getUserRepos` into `getUserAndRepos` using axios
- Remove GET_USERS Case, Update GET_USER Case
  - Update `GET_USER` to `GET_USER_AND_REPOS` case
  - Pull out both `user` & `repos` payloads
  - Delete `GET_REPOS` case
- Update `GithubActions` Extract, Update `useEffect`
  - Remove old extracts, extract `getUserAndRepos` from `GithubActions`
  - Update `useEffect` hook to use `getUserAndRepos` function
  - Remove reference in `useEffect` to old extracted functions
- Swapped a `/` for `?`

Minimal testing was performed by just running the "dev" server and making live changes in the code to see those changes reflected in the UI as well as in the Chrome React Developer Tools.

Resolves #24